### PR TITLE
Fix PWM to work with DRV8701

### DIFF
--- a/include/Autosteer.h
+++ b/include/Autosteer.h
@@ -14,7 +14,7 @@
    Like all Arduino code - copied from somewhere else :)
    So don't claim it as your own
 */
-const uint8_t PWM_Frequency = 2;
+const uint8_t PWM_Frequency = 3;
 const float LOW_HIGH_DEGREES = 3.0; // How many degrees before decreasing Max PWM
 
 bool testBothWasSensors = false;
@@ -105,6 +105,11 @@ void autosteerSetup()
   {
     analogWriteFrequency(PWM1_PIN, 3921);
     analogWriteFrequency(PWM2_PIN, 3921);
+  } 
+  else if (PWM_Frequency == 3) 
+  {
+    analogWriteFrequency(PWM1_PIN, 9155);
+    analogWriteFrequency(PWM2_PIN, 9155);
   }
 
   pinMode(SLEEP_PIN, OUTPUT);

--- a/include/AutosteerPID.h
+++ b/include/AutosteerPID.h
@@ -82,14 +82,14 @@ void motorDrive(void)
   // Cytron drv8701P Driver PWM1 + PWM2 Signal (like prev IBT2 option)
   if (pwmDrive > 0)
   {
-    analogWrite(PWM2_PIN, 0); // Turn off before other one on
-    analogWrite(PWM1_PIN, pwmDrive);
+    analogWrite(PWM2_PIN, 255); // Turn off before other one on
+    analogWrite(PWM1_PIN, 255-pwmDrive);
   }
   else
   {
     pwmDrive = -1 * pwmDrive;
-    analogWrite(PWM1_PIN, 0); // Turn off before other one on
-    analogWrite(PWM2_PIN, pwmDrive);
+    analogWrite(PWM1_PIN, 255); // Turn off before other one on
+    analogWrite(PWM2_PIN, 255-pwmDrive);
   }
 
   pwmDisplay = pwmDrive;


### PR DESCRIPTION
Fix the PWM output to be normally high polarity to match with DRV8701 data sheet expectations.

Added a new, higher frequency to PWM options for the DC motor type auto steer systems.